### PR TITLE
Extend dependencies list

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
   
 On Ubuntu 16.04 and 18.04, most of the dependencies can be installed from the package manager:
 ```bash
-sudo apt install git libeigen3-dev libboost-all-dev qtbase5-dev libglew-dev catkin
+sudo apt install git libeigen3-dev libboost-all-dev qtbase5-dev libglew-dev catkin google-mock
 ```
 
 Additionally, make sure you have [catkin-tools](https://catkin-tools.readthedocs.io/en/latest/) and the [fetch](https://github.com/Photogrammetry-Robotics-Bonn/catkin_tools_fetch) verb installed:

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
   
 On Ubuntu 16.04 and 18.04, most of the dependencies can be installed from the package manager:
 ```bash
-sudo apt install git libeigen3-dev libboost-all-dev qtbase5-dev libglew-dev catkin google-mock
+sudo apt install git libeigen3-dev libboost-all-dev qtbase5-dev libglew-dev catkin libgtest-dev
 ```
 
 Additionally, make sure you have [catkin-tools](https://catkin-tools.readthedocs.io/en/latest/) and the [fetch](https://github.com/Photogrammetry-Robotics-Bonn/catkin_tools_fetch) verb installed:


### PR DESCRIPTION
### Version 2 of this PR:

Having no `libgtest-dev` package installed, I faced the following issue when running `catkin build`:

```
fatal error: gtest/gtest.h: No such file or directory
  ```

Solution is to run `sudo apt install libgtest-dev`
### Version 1 of this PR:

Having no `google-mock` package installed, I faced the following issue when running `catkin build`:

```
CMake Error at /home/master/.conda/envs/sc/lib/python3.9/site-packages/cmake/data/share/cmake-3.26/Modules/ExternalProject.cmake:3131 (message):
  No download info given for 'GMock' and its source directory:

   /usr/src/gmock

  is not an existing non-empty directory.  Please specify one of:

   * SOURCE_DIR with an existing non-empty directory
   * DOWNLOAD_COMMAND
   * URL
   * GIT_REPOSITORY
   * SVN_REPOSITORY
   * HG_REPOSITORY
   * CVS_REPOSITORY and CVS_MODULE
  ```

Solution is to do `sudo apt install google-mock`.

However, installing the package `google-mock` manually led to issues on other build stages. The ultimate solution was to reinstall `point_labeler` from scratch.